### PR TITLE
feat(plugin): update code to reflect changes in hvac `v1.0.0`

### DIFF
--- a/certbot_vault/plugin.py
+++ b/certbot_vault/plugin.py
@@ -71,7 +71,7 @@ class VaultInstaller(common.Plugin):
 
         if self.conf('role-id') and self.conf('secret-id'):
             auth_mount_point = self.conf('auth-path') or 'approle'
-            self.hvac_client.auth_approle(
+            self.hvac_client.auth.approle.login(
                 self.conf('role-id'),
                 self.conf('secret-id'),
                 mount_point=auth_mount_point


### PR DESCRIPTION
`auth_approle` method has been removed since `hvac` `v1.0.0`.
-> https://github.com/hvac/hvac/pull/868

Swith to `auth.approle.login` instead